### PR TITLE
Randomize Islands gives an even random translation spread

### DIFF
--- a/operators/randomize_islands.py
+++ b/operators/randomize_islands.py
@@ -105,14 +105,14 @@ class RandomizeIslands(Operator):
                 bbox = get_bbox(uv, island)
                 bbox_center = calc_bbox_center(bbox)
 
-                distance_u, distance_v = 0, 0
-                if self.tranlate_u or self.tranlate_v:
-                    distance = random.uniform(
-                        self.tranlate_limit * -1, self.tranlate_limit)
-                    if self.tranlate_u:
-                        distance_u = distance
-                    if self.tranlate_v:
-                        distance_v = distance
+                if self.tranlate_u:
+                    distance_u = random.uniform(self.tranlate_limit * -1, self.tranlate_limit)
+                else:
+                    distance_u = 0
+                if self.tranlate_v:
+                    distance_v = random.uniform(self.tranlate_limit * -1, self.tranlate_limit)
+                else:
+                    distance_v = 0
                 tranlate = translate_matrix(distance_u, distance_v)
 
                 angle = 0

--- a/operators/randomize_islands.py
+++ b/operators/randomize_islands.py
@@ -102,6 +102,10 @@ class RandomizeIslands(Operator):
         random.seed(self.seed)
 
         objects_seams = get_objects_seams(context)
+        translate_limit = self.translate_limit
+        angle_limit = self.angle_limit
+        scale_limit = self.scale_limit
+
         for ob in context.objects_in_mode_unique_data:
             seams = objects_seams[ob]
             me = ob.data
@@ -112,37 +116,23 @@ class RandomizeIslands(Operator):
                 bbox = get_bbox(uv, island)
                 bbox_center = calc_bbox_center(bbox)
 
-                if self.translate_u:
-                    distance_u = random.uniform(self.translate_limit * -1, self.translate_limit)
-                else:
-                    distance_u = 0
-                if self.translate_v:
-                    distance_v = random.uniform(self.translate_limit * -1, self.translate_limit)
-                else:
-                    distance_v = 0
+                distance_u = random.uniform(-translate_limit, translate_limit) if self.translate_u else 0
+                distance_v = random.uniform(-translate_limit, translate_limit) if self.translate_v else 0
                 translate = translate_matrix(distance_u, distance_v)
 
-                angle = 0
                 if self.cw and self.ccw:
-                    angle = random.uniform(
-                        self.angle_limit * -1, self.angle_limit)
-                if self.cw and not self.ccw:
-                    angle = random.uniform(self.angle_limit * -1, 0)
-                if self.ccw and not self.cw:
-                    angle = random.uniform(0, self.angle_limit)
+                    angle = random.uniform(-angle_limit, angle_limit)
+                elif self.cw:
+                    angle = random.uniform(-angle_limit, 0)
+                elif self.ccw:
+                    angle = random.uniform(0, angle_limit)
+                else:
+                    angle = 0
                 rotate = universal_rotation_matrix(context, radians(angle), bbox_center)
 
-                scale_u, scale_v = 1, 1
-                if self.scale_uniform or self.scale_u or self.scale_v:
-                    scale_factor = 1 + random.uniform(
-                        self.scale_limit * -1, self.scale_limit)
-                    if self.scale_uniform:
-                        scale_u = scale_factor
-                        scale_v = scale_factor
-                    if self.scale_u:
-                        scale_u = scale_factor
-                    if self.scale_v:
-                        scale_v = scale_factor
+                scale_factor = 1 + random.uniform(-scale_limit, scale_limit) if (self.scale_uniform or self.scale_u or self.scale_v) else 1
+                scale_u = scale_factor if self.scale_uniform or self.scale_u else 1
+                scale_v = scale_factor if self.scale_uniform or self.scale_v else 1
                 scale = scale_matrix((scale_u, scale_v), bbox_center)
 
                 rotate_scale = np.dot(rotate, scale)


### PR DESCRIPTION
Randomize Islands used the same random distance value for U and V which resulted in an ugly diagonal distribution. It now uses separate random values for U and V for a correct random distribution.