### PR TITLE
Set Active UV defaults to using name if provided

### DIFF
--- a/operators/set_active_uv_layer.py
+++ b/operators/set_active_uv_layer.py
@@ -24,6 +24,14 @@ class SetActiveUvLayer(Operator):
         default=True,
     )
 
+    def invoke(self, context, event):
+        scene = context.scene
+        if scene.uv_toolkit.uv_layer_name != "":
+            self.mode = "NAME"
+        else:
+            self.mode = "INDEX"
+        return self.execute(context)
+
     def execute(self, context):
         scene = context.scene
         ob = context.active_object


### PR DESCRIPTION
The operator is now more connected with the panel, and uses the correct mode depending on if a name was entered or not, speeding up its usage.